### PR TITLE
Break up pipeline into stages

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -12,135 +12,158 @@ pr:
 pool:
   vmImage: windows-latest
 
-strategy:
-  matrix:
-    PowerShell 7:
-      pwsh: true
-    PowerShell 5.1:
-      pwsh: false
+stages:
+- stage:
+  displayName: lint and build
+  jobs:
+  - job:
+    steps:
+    - pwsh: Invoke-ScriptAnalyzer . -Recurse -ReportSummary -EnableExit
+      displayName: run script analyzer
+    - pwsh: .\Build.ps1
+      displayName: build module
+    - publish: ./output
+      artifact: module
+      displayName: publish module artifact
+- stage:
+  displayName: test
+  jobs:
+  - job:
+    strategy:
+      matrix:
+        PowerShell 7:
+          pwsh: true
+        PowerShell 5.1:
+          pwsh: false
+    steps:
+    - download: current
+      artifact: module
+      displayName: download module artifact
+    - task: PowerShell@2
+      displayName: install PowerShellGet v3
+      inputs:
+        targetType: inline
+        pwsh: $(pwsh)
+        script: |
+          Install-Module PowerShellGet -RequiredVersion '3.0.17-beta17' -AllowPrerelease -Force
+    - pwsh: |
+        $dir = New-Item $(Agent.TempDirectory)\LocalRepo -ItemType directory
+        Register-PSResourceRepository LocalRepo -Uri $dir -Trusted
+      displayName: register local powershell repository
+    - pwsh: Publish-PSResource -Path $(Pipeline.Workspace)\module -Repository LocalRepo
+      displayName: publish module to local repository
+    - task: PowerShell@2
+      displayName: install module from local repo
+      inputs:
+        targetType: inline
+        pwsh: $(pwsh)
+        script: |
+          Install-PSResource AzPipelineVariable -Repository LocalRepo -Prerelease -Verbose
+    - task: PowerShell@2
+      displayName: run unit tests
+      inputs:
+        targetType: inline
+        pwsh: $(pwsh)
+        script: |
+          Import-Module AzPipelineVariable -Verbose
+          Invoke-Pester -Configuration (New-PesterConfiguration @{
+            TestResult = @{
+              Enabled = $true
+              OutputFormat = 'NUnitXml'
+              OutputPath = 'unitTestResults.xml'
+            }
+            Run = @{
+              Container = New-PesterContainer `
+                -Path 'AzPipelineVariable.Tests.ps1' `
+                -Data @{ SkipImport = $true }
+            }
+          })
+    - task: PublishTestResults@2
+      displayName: publish test results
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: unitTestResults.xml
+        testResultsFormat: NUnit
+        testRunTitle: Unit Tests
+    - task: PowerShell@2
+      displayName: set variables for smoke test
+      name: setVars
+      inputs:
+        targetType: inline
+        pwsh: $(pwsh)
+        script: |
+          Set-AzPipelineVariable normalVar xyz
+          Set-AzPipelineVariable outputVar xyz -Output
+          # "secret" is a resevered prefix
+          Set-AzPipelineVariable aSecretVar1 xyz -Secret
+          Set-AzPipelineVariable aSecretVar2 xyz -Secret
+          Set-AzPipelineVariable mutableVar xyz -Mutable
+          Set-AzPipelineVariable emptyVar $null
+    - task: PowerShell@2
+      displayName: mutate var
+      inputs:
+        targetType: inline
+        pwsh: $(pwsh)
+        script: Set-AzPipelineVariable mutableVar 'mutated'
+    - task: PowerShell@2
+      displayName: run integration test
+      inputs:
+        targetType: inline
+        pwsh: $(pwsh)
+        script: |
+          Import-Module AzPipelineVariable
 
-steps:
-- task: PowerShell@2
-  displayName: install PowerShellGet v3
-  inputs:
-    targetType: inline
-    pwsh: $(pwsh)
-    script: |
-      Install-Module PowerShellGet -RequiredVersion '3.0.17-beta17' -AllowPrerelease -Force
-- pwsh: Invoke-ScriptAnalyzer . -Recurse -ReportSummary -EnableExit
-  displayName: run script analyzer
-- pwsh: |
-    $dir = New-Item $(Agent.TempDirectory)\LocalRepo -ItemType directory
-    Register-PSResourceRepository LocalRepo -Uri $dir -Trusted
-  displayName: register local powershell repository
-- pwsh: .\Build.ps1
-  displayName: build module
-- pwsh: Publish-PSResource -Path .\output -Repository LocalRepo
-  displayName: publish module to local repository
-- task: PowerShell@2
-  displayName: install module from local repo
-  inputs:
-    targetType: inline
-    pwsh: $(pwsh)
-    script: |
-      Install-PSResource AzPipelineVariable -Repository LocalRepo -Prerelease -Verbose
-- task: PowerShell@2
-  displayName: run unit tests
-  inputs:
-    targetType: inline
-    pwsh: $(pwsh)
-    script: |
-      Import-Module AzPipelineVariable -Verbose
-      Invoke-Pester -Configuration (New-PesterConfiguration @{
-        TestResult = @{
-          Enabled = $true
-          OutputFormat = 'NUnitXml'
-          OutputPath = 'unitTestResults.xml'
-        }
-        Run = @{
-          Container = New-PesterContainer `
-            -Path 'AzPipelineVariable.Tests.ps1' `
-            -Data @{ SkipImport = $true }
-        }
-      })
-- task: PublishTestResults@2
-  displayName: publish test results
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFiles: unitTestResults.xml
-    testResultsFormat: NUnit
-    testRunTitle: Unit Tests
-- task: PowerShell@2
-  displayName: set variables for smoke test
-  name: setVars
-  inputs:
-    targetType: inline
-    pwsh: $(pwsh)
-    script: |
-      Set-AzPipelineVariable normalVar xyz
-      Set-AzPipelineVariable outputVar xyz -Output
-      # "secret" is a resevered prefix
-      Set-AzPipelineVariable aSecretVar1 xyz -Secret
-      Set-AzPipelineVariable aSecretVar2 xyz -Secret
-      Set-AzPipelineVariable mutableVar xyz -Mutable
-      Set-AzPipelineVariable emptyVar $null
-- task: PowerShell@2
-  displayName: mutate var
-  inputs:
-    targetType: inline
-    pwsh: $(pwsh)
-    script: Set-AzPipelineVariable mutableVar 'mutated'
-- task: PowerShell@2
-  displayName: run integration test
-  inputs:
-    targetType: inline
-    pwsh: $(pwsh)
-    script: |
-      Import-Module AzPipelineVariable
-
-      Invoke-Pester -Configuration (New-PesterConfiguration @{
-        TestResult = @{
-          Enabled = $true
-          OutputFormat = 'NUnitXml'
-          OutputPath = 'integrationTestResults.xml'
-        }
-        Run = @{
-          Container = New-PesterContainer `
-          -ScriptBlock {
-            Describe 'Set-AzPipelineVariable' {
-              It 'normal var' {
-                '$(normalVar)' | Should -Be 'xyz'
-              }
-              It 'output var' {
-                '$(setVars.outputVar)' | Should -Be 'xyz'
-              }
-              It 'mapped secret var' {
-                $ENV:ASECRETVAR1 | Should -Be 'xyz'
-              }
-              It 'unmapped secret var' {
-                $ENV:ASECRETVAR2 | Should -Be $null
-              }
-              It 'mutable var' {
-                '$(mutableVar)' | Should -Be 'mutated'
-              }
-              It 'empty var' {
-                '$(emptyVar)' | Should -Be ''
+          Invoke-Pester -Configuration (New-PesterConfiguration @{
+            TestResult = @{
+              Enabled = $true
+              OutputFormat = 'NUnitXml'
+              OutputPath = 'integrationTestResults.xml'
+            }
+            Run = @{
+              Container = New-PesterContainer `
+              -ScriptBlock {
+                Describe 'Set-AzPipelineVariable' {
+                  It 'normal var' {
+                    '$(normalVar)' | Should -Be 'xyz'
+                  }
+                  It 'output var' {
+                    '$(setVars.outputVar)' | Should -Be 'xyz'
+                  }
+                  It 'mapped secret var' {
+                    $ENV:ASECRETVAR1 | Should -Be 'xyz'
+                  }
+                  It 'unmapped secret var' {
+                    $ENV:ASECRETVAR2 | Should -Be $null
+                  }
+                  It 'mutable var' {
+                    '$(mutableVar)' | Should -Be 'mutated'
+                  }
+                  It 'empty var' {
+                    '$(emptyVar)' | Should -Be ''
+                  }
+                }
               }
             }
-          }
-        }
-      })
-  env:
-    ASECRETVAR1: $(aSecretVar1)
-- task: PublishTestResults@2
-  displayName: publish test results
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFiles: integrationTestResults.xml
-    testResultsFormat: NUnit
-    testRunTitle: Integration Tests
-- pwsh: |
-    Publish-PSResource -Path .\output -Repository PSGallery -ApiKey $Env:API_KEY -Verbose
+          })
+      env:
+        ASECRETVAR1: $(aSecretVar1)
+    - task: PublishTestResults@2
+      displayName: publish test results
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: integrationTestResults.xml
+        testResultsFormat: NUnit
+        testRunTitle: Integration Tests
+- stage:
+  displayName: publish
   condition: and(succeeded(), eq('${{ parameters.forceRelease }}', 'true'))
-  env:
-    API_KEY: $(PSGalleryApiKey)
+  jobs:
+  - job:
+    steps:
+    - download: current
+      artifact: module
+      displayName: download module artifact
+    - pwsh: |
+        Publish-PSResource -Path $(Pipeline.Workspace)\module -Repository PSGallery -ApiKey $Env:API_KEY -Verbose
+      env:
+        API_KEY: $(PSGalleryApiKey)


### PR DESCRIPTION
This is necessary since we only want to run the tests with the matrix. Other tasks (linting, publishing) should only run once.